### PR TITLE
Bump base-x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6843,9 +6843,9 @@
       "license": "MIT"
     },
     "node_modules/base-x": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.0.tgz",
-      "integrity": "sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -6942,9 +6942,9 @@
       }
     },
     "node_modules/bitsharesjs/node_modules/base-x": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
-      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.0.1"


### PR DESCRIPTION
Bumps  and [base-x](https://github.com/cryptocoinjs/base-x). These dependencies needed to be updated together.

Updates `base-x` from 3.0.10 to 5.0.1
- [Commits](https://github.com/cryptocoinjs/base-x/compare/v3.0.10...v5.0.1)

Updates `base-x` from 5.0.0 to 5.0.1
- [Commits](https://github.com/cryptocoinjs/base-x/compare/v3.0.10...v5.0.1)

---
updated-dependencies:
- dependency-name: base-x dependency-version: 5.0.1 dependency-type: indirect
- dependency-name: base-x dependency-version: 5.0.1 dependency-type: indirect ...